### PR TITLE
Update github action push-kaggle-dataset to version v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
 
     - name: Upload as Kaggle Dataset
-      uses: jaimevalero/push-kaggle-dataset@v1.0.2
+      uses: jaimevalero/push-kaggle-dataset@v3
       env:
         KAGGLE_USERNAME: ${{ inputs.kaggle_username }}
         KAGGLE_KEY: ${{ inputs.kaggle_key }}


### PR DESCRIPTION
Hi @ayulockin 

There is a [bug]( https://github.com/jaimevalero/push-kaggle-dataset/issues/8 ) in the used version v.1.0.2.
Please consider updating to version v3.
This PR is for your convenience ;-)

Disclaimer : I am the author of the action

BTW, great work integrating the action ! I am glad you find it useful
